### PR TITLE
Reduce the number of permissions required

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,8 @@
     "es6": true,
     "amd": true,
     "webextensions": true
+  },
+  "parserOptions": {
+    "sourceType": "module"
   }
 }

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,29 +1,31 @@
 {
-    "manifest_version": 2,
-    "name": "Advent of Code to Markdown",
-    "version": "1.0.11",
-    "description": "Converts a given Advent of Code page to a GitHub-compatible Markdown file.",
-    "icons": {
-        "16": "icons/aoc-to-markdown-16.png",
-        "32": "icons/aoc-to-markdown-32.png",
-        "48": "icons/aoc-to-markdown-48.png",
-        "128": "icons/aoc-to-markdown-128.png"
+  "manifest_version": 2,
+  "name": "Advent of Code to Markdown",
+  "version": "1.0.11",
+  "description": "Converts a given Advent of Code page to a GitHub-compatible Markdown file.",
+  "icons": {
+    "16": "icons/aoc-to-markdown-16.png",
+    "32": "icons/aoc-to-markdown-32.png",
+    "48": "icons/aoc-to-markdown-48.png",
+    "128": "icons/aoc-to-markdown-128.png"
+  },
+  "background": {
+    "scripts": ["background_scripts/index.js"]
+  },
+  "content_scripts": [
+    {
+      "js": ["/content_scripts/index.js"],
+      "matches": ["*://adventofcode.com/*/day/*"]
+    }
+  ],
+  "page_action": {
+    "default_icon": {
+      "16": "icons/aoc-to-markdown-16.png",
+      "32": "icons/aoc-to-markdown-32.png",
+      "48": "icons/aoc-to-markdown-48.png",
+      "128": "icons/aoc-to-markdown-128.png"
     },
-    "page_action": {
-        "default_icon": {
-            "16": "icons/aoc-to-markdown-16.png",
-            "32": "icons/aoc-to-markdown-32.png",
-            "48": "icons/aoc-to-markdown-48.png",
-            "128": "icons/aoc-to-markdown-128.png"
-        },
-        "default_title": "Advent of Code to Markdown"
-    },
-    "background": {
-        "scripts": ["background_scripts/index.js"]
-    },
-    "permissions": [
-        "activeTab",
-        "tabs",
-        "downloads"
-    ]
+    "default_title": "Advent of Code to Markdown"
+  },
+  "permissions": ["downloads"]
 }

--- a/content_scripts/on-loaded.js
+++ b/content_scripts/on-loaded.js
@@ -1,0 +1,9 @@
+import { runtime } from "webextension-polyfill";
+
+runtime
+  .sendMessage({
+    action: "showPageAction",
+  })
+  .catch((err) =>
+    console.error("Failed to send 'showPageAction' message", err)
+  );

--- a/content_scripts/to-markdown.js
+++ b/content_scripts/to-markdown.js
@@ -1,56 +1,65 @@
-const browser = require("webextension-polyfill");
-const gfm = require('turndown-plugin-gfm').gfm;
-const TurndownService = require('turndown').default;
+import { runtime } from "webextension-polyfill";
+import { gfm } from "turndown-plugin-gfm";
+import TurndownService from "turndown";
 
-function stripHyphens (str) {
-    const regex = /^--- (.+) ---$/;
-    return str.replace(regex, (match, p1) => {
-        return p1;
-    });
+function stripHyphens(str) {
+  const regex = /^--- (.+) ---$/;
+  return str.replace(regex, (match, p1) => {
+    return p1;
+  });
 }
 
-const newDoc = document.createDocumentFragment();
-const titleElement = document.createElement('h1');
-newDoc.appendChild(titleElement);
+function capturePage() {
+  const newDoc = document.createDocumentFragment();
+  const titleElement = document.createElement("h1");
+  newDoc.appendChild(titleElement);
 
-const link = document.createElement('a');
-const href = window.location.origin + window.location.pathname
-link.href = href;
-link.innerText = href;
-newDoc.appendChild(link);
+  const link = document.createElement("a");
+  const href = window.location.origin + window.location.pathname;
+  link.href = href;
+  link.innerText = href;
+  newDoc.appendChild(link);
 
-const descriptionHeader = document.createElement('h2');
-descriptionHeader.innerText = 'Description';
-newDoc.appendChild(descriptionHeader);
+  const descriptionHeader = document.createElement("h2");
+  descriptionHeader.innerText = "Description";
+  newDoc.appendChild(descriptionHeader);
 
-const articleElements = document.querySelectorAll('article');
-const articleElementsLength = articleElements.length;
-for (let index = 0; index < articleElementsLength; ++index) {
+  const articleElements = document.querySelectorAll("article");
+  const articleElementsLength = articleElements.length;
+  for (let index = 0; index < articleElementsLength; ++index) {
     const article = articleElements[index].cloneNode(true);
-    const headingElement = article.querySelector('h2');
+    const headingElement = article.querySelector("h2");
     let heading = stripHyphens(headingElement.innerText);
 
     if (index === 0) {
-        titleElement.innerText = heading;
-        heading = 'Part One';
+      titleElement.innerText = heading;
+      heading = "Part One";
     }
 
-    const newHeadingElement = document.createElement('h3');
+    const newHeadingElement = document.createElement("h3");
     newHeadingElement.innerText = heading;
     headingElement.replaceWith(newHeadingElement);
 
     newDoc.appendChild(article);
+  }
+
+  const turndownService = new TurndownService({
+    headingStyle: "atx",
+  });
+  turndownService.use(gfm);
+  turndownService.keep(["span"]);
+
+  return turndownService.turndown(newDoc).concat("\n");
 }
 
-const turndownService = new TurndownService({
-    headingStyle: 'atx'
-});
-turndownService.use(gfm);
-turndownService.keep(['span']);
-
-const markdown = turndownService.turndown(newDoc).concat('\n');
-
-browser.runtime.sendMessage({
-    action: "saveAs",
-    text: markdown,
+runtime.onMessage.addListener((data) => {
+  if (data.action === "capturePage") {
+    const markdown = capturePage();
+    return runtime
+      .sendMessage({
+        action: "saveAs",
+        text: markdown,
+      })
+      .catch((err) => console.error("Failed to send 'saveAs' message", err));
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1783,7 +1783,7 @@
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
@@ -5528,7 +5528,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -6073,7 +6073,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "optional": true,
@@ -6242,7 +6242,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -6929,7 +6929,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,16 @@
 const path = require("path");
 
 module.exports = {
-    mode: "production",
-    entry: {
-        background_scripts: "./background_scripts/background.js",
-        content_scripts: "./content_scripts/to-markdown.js"
-    },
-    output: {
-        path: path.resolve(__dirname, "addon"),
-        filename: "[name]/index.js"
-    }
+  mode: "production",
+  entry: {
+    background_scripts: ["./background_scripts/background.js"],
+    content_scripts: [
+      "./content_scripts/on-loaded.js",
+      "./content_scripts/to-markdown.js",
+    ],
+  },
+  output: {
+    path: path.resolve(__dirname, "addon"),
+    filename: "[name]/index.js",
+  },
 };


### PR DESCRIPTION
## Overview

The existing solution has some issues, especially on Chrome and Edge:

- It requires broad permission that let it access tab details (like the current URI) as well as any page that's active when the extension is triggered.
- Listens to many unnecessary tab events to try and handle all possible cases.
- Chrome/Edge: The pageAction appears clickable on all pages. On unsupported pages it just opens the default context menu, but otherwise looks the same.

## Solution

### Current

The current approach unnecessarily uses the `activeTab` permissions when the domain permission would do (e.g. `*://adventofcode.com/*`). Unfortunately on Chrome this seems to forcibly light up the button anywhere on the web, even when the button has been disabled (using `pageAction.hide()`). It also requires the `tabs` permission which allows the extension to read the URI from any tab in the user's browser.

In order to control the visibility of the button the background script scans all tabs to check for existing Advent of Code pages and then listens to all `onUpdated` events that the tabs raise. This is a lot of events and still misses some key browser interactions. When the user clicked on the `pageAction` it would inject the content script into the active page and wait for it to call back to save the contents.

A few discoveries:

- The default state for `pageAction` is hidden and it hides again on each navigation, only show it when you need it.
- For Chrome the button is only grayed out when the extension is unable to interact with the site (due to domain restrictions).
- Chrome and Firefox have incompatible methods of dynamically showing the button based on the URI (`manifest.json` for Firefox, `declarativeContent` API for Chrome). Chrome still won't gray the button out when `pageAction.hide()` is called, it just stops the action from firing.
- Both support dynamically inserting content scripts via `manifest.json` based on a URI match pattern.

### Updated solution

Given these learnings/issues, the approach taken is to lean on the content scripts to do the heavy lifting. The extension declares that the content scripts be injected on every page which matches `*://adventofcode.com/*/day/*`. Since we declare no other permissions (besides `download` to enable saving the file), the implicit permissions of the content script win out. This means that on Chrome the button is grayed out until a page is reached which allows the script to be injected.

When the content script loads it fires off a `showPageAction` message to the background script which then activates the button (any navigation will reset the state back, so no need to hide it again).

When the user clicks the extension button:

1. The `pageAction` handler fires a `capturePage` event to the active tab.
2. The content script receives the message and converts the page content to markdown.
3. The content script fires a `saveAs` event.
4. The background script receives the message and converts the content to a downloadable blob.
5. The `download` API is invoked to allow the user to save the file.

This seems to avoid the potential pitfalls above, limiting the permission to just the specific pages and browser downloads. It also seems to behave better overall on Firefox, Chrome, and Edge.