### PR TITLE
Small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run compile && web-ext build -n aoc-to-markdown-addon.zip -s addon --overwrite-dest",
     "compile": "npm run genmanifest && webpack",
     "genmanifest": "node ./tools/genmanifest.js ./src/manifest.json ./addon/manifest.json",
-    "lint": "eslint . && web-ext lint -s addon",
+    "lint": "eslint . && npm run compile && web-ext lint -s addon",
     "lint-fix": "eslint . --fix",
     "prepare": "npm run compile",
     "prestart": "npm run compile",

--- a/src/content_scripts/to-markdown.js
+++ b/src/content_scripts/to-markdown.js
@@ -47,7 +47,7 @@ function generateMarkdown(doc) {
   // ```html
   // <code>1 + 1 = <em>2</em></code>
   // ```
-  // 
+  //
   // The default rendering results in the underscores being rendered, as there
   // isn't a proper way to render emphasis within code blocks without resorting
   // to HTML again. In this case the best solution is to drop the emphasis
@@ -57,8 +57,7 @@ function generateMarkdown(doc) {
   // where the previous code did not make a modification.
   turndownService.addRule("emphasisWithinCode", {
     filter: (node) =>
-      node.nodeName == "EM" &&
-      node.parentNode.nodeName == "CODE",
+      node.nodeName == "EM" && node.parentNode.nodeName == "CODE",
     replacement: (content) => content,
   });
 
@@ -75,7 +74,7 @@ function expandHrefs(article) {
     if (link.href) {
       // Reading the `href` seems to expand it, setting it back will make it
       // permanent.
-      link.href = link.href
+      link.href = link.href;
     }
   }
 }


### PR DESCRIPTION
- Compile before linting since the web-ext lint step runs on the compiled outputs
- Run prettier on src files
