### PR TITLE
Download the markdown from the content script

### DIFF
--- a/src/background_scripts/background.js
+++ b/src/background_scripts/background.js
@@ -5,24 +5,8 @@ import {
   tabs as _tabs,
 } from "webextension-polyfill";
 
-function saveAs(text) {
-  const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
-
-  return downloads.download({
-    url: URL.createObjectURL(blob),
-    filename: "README.md",
-    saveAs: true,
-  });
-}
-
 runtime.onMessage.addListener((data, sender) => {
   switch (data.action) {
-    case "saveAs":
-      saveAs(data.text).catch((err) => {
-        console.error("Failed to save content", err);
-      });
-      break;
-
     case "showPageAction":
       pageAction.show(sender.tab.id);
       break;

--- a/src/content_scripts/to-markdown.js
+++ b/src/content_scripts/to-markdown.js
@@ -79,6 +79,16 @@ function expandHrefs(article) {
   }
 }
 
+function downloadBlob(blob) {
+  const downloadLink = document.createElement('a');
+  downloadLink.href = URL.createObjectURL(blob);
+  downloadLink.download = 'README.md';
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+  URL.revokeObjectURL(downloadLink.href);
+}
+
 function capturePage() {
   const newDoc = document.createDocumentFragment();
   const titleElement = document.createElement("h1");
@@ -116,20 +126,12 @@ function capturePage() {
   }
 
   const text = generateMarkdown(newDoc);
-  return new Blob([text], { type: "text/markdown;charset=utf-8" });
+  const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
+  downloadBlob(blob);
 }
 
 runtime.onMessage.addListener((data) => {
   if (data.action === "capturePage") {
-    const blob = capturePage();
-
-    // Create a link element to trigger the download
-    const downloadLink = document.createElement('a');
-    downloadLink.href = URL.createObjectURL(blob);
-    downloadLink.download = 'README.md';
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
-    URL.revokeObjectURL(downloadLink.href);
+    capturePage();
   }
 });

--- a/src/content_scripts/to-markdown.js
+++ b/src/content_scripts/to-markdown.js
@@ -115,17 +115,21 @@ function capturePage() {
     newDoc.appendChild(article);
   }
 
-  return generateMarkdown(newDoc);
+  const text = generateMarkdown(newDoc);
+  return new Blob([text], { type: "text/markdown;charset=utf-8" });
 }
 
 runtime.onMessage.addListener((data) => {
   if (data.action === "capturePage") {
-    const markdown = capturePage();
-    return runtime
-      .sendMessage({
-        action: "saveAs",
-        text: markdown,
-      })
-      .catch((err) => console.error("Failed to send 'saveAs' message", err));
+    const blob = capturePage();
+
+    // Create a link element to trigger the download
+    const downloadLink = document.createElement('a');
+    downloadLink.href = URL.createObjectURL(blob);
+    downloadLink.download = 'README.md';
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
+    URL.revokeObjectURL(downloadLink.href);
   }
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,4 +13,7 @@ module.exports = {
     path: path.resolve(__dirname, "addon"),
     filename: "[name]/index.js",
   },
+  optimization: {
+    minimize: false,
+  },
 };


### PR DESCRIPTION
There are complexities that arise from passing the content to the
background script, especially when moving to Manifest V3. Avoid this by
just triggering the download directly from the content script.
