### PR TITLE
Handle back/forward navigation

### DIFF
--- a/src/background_scripts/background.js
+++ b/src/background_scripts/background.js
@@ -1,5 +1,4 @@
 import {
-  downloads,
   runtime,
   pageAction,
   tabs as _tabs,

--- a/src/content_scripts/on-loaded.js
+++ b/src/content_scripts/on-loaded.js
@@ -1,9 +1,14 @@
 import { runtime } from "webextension-polyfill";
 
-runtime
-  .sendMessage({
-    action: "showPageAction",
-  })
-  .catch((err) =>
-    console.error("Failed to send 'showPageAction' message", err)
-  );
+function showPageAction() {
+  runtime.sendMessage({ action: "showPageAction" }).catch((err) => {
+    console.error("Failed to send 'showPageAction' message", err);
+  });
+}
+
+// Detect history navigation (back/forward)
+window.addEventListener("pageshow", () => {
+  showPageAction();
+});
+
+showPageAction();


### PR DESCRIPTION
When navigating using back/forward, the action can get out of sync with the page. Listen to the `pageshow` event to ensure the action state is correct.

https://web.dev/articles/bfcache
