### PR TITLE
Remove unnecessary download permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,5 @@
       "128": "icons/aoc-to-markdown-128.png"
     },
     "default_title": "Advent of Code to Markdown"
-  },
-  "permissions": ["downloads"]
+  }
 }


### PR DESCRIPTION
Since the downloads are triggered from within the content, no special permissions are required.
