### PR TITLE
Fix startup issue on Chrome

### DIFF
--- a/src/background_scripts/background.js
+++ b/src/background_scripts/background.js
@@ -20,6 +20,10 @@ runtime.onInstalled.addListener(() => {
   action.disable();
 });
 
+runtime.onStartup.addListener(() => {
+  action.disable();
+});
+
 action.onClicked.addListener(() => {
   _tabs
     .query({ active: true, currentWindow: true })


### PR DESCRIPTION
The action needs to be disabled on each startup otherwise it will stay
enabled for all pages. Add the `onStartup` listener to also disable the
action.
