### PR TITLE
Update GitHub Actions to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,40 +8,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 24.x
       - run: npm ci
       - run: npm run lint
       - run: npm run build
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        run: |
+          mv ./web-ext-artifacts/aoc-to-markdown-chrome.zip ./web-ext-artifacts/aoc-to-markdown-chrome-${{ github.ref_name }}.zip
+          mv ./web-ext-artifacts/aoc-to-markdown-firefox.zip ./web-ext-artifacts/aoc-to-markdown-firefox-${{ github.ref_name }}.zip
+          gh release create ${{ github.ref_name }} \
+            --title "Advent of Code to Markdown ${{ github.ref_name }}" \
+            ./web-ext-artifacts/aoc-to-markdown-chrome-${{ github.ref_name }}.zip \
+            ./web-ext-artifacts/aoc-to-markdown-firefox-${{ github.ref_name }}.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Advent of Code to Markdown ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset - Chrome
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./web-ext-artifacts/aoc-to-markdown-chrome.zip
-          asset_name: aoc-to-markdown-chrome-${{ github.ref }}.zip
-          asset_content_type: application/zip
-      - name: Upload Release Asset - Firefox
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./web-ext-artifacts/aoc-to-markdown-firefox.zip
-          asset_name: aoc-to-markdown-firefox-${{ github.ref }}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aoc-to-markdown",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Converts a given Advent of Code page to a GitHub-compatible Markdown file.",
   "repository": "github:kfarnung/aoc-to-markdown",
   "scripts": {


### PR DESCRIPTION
## Summary

Updates all GitHub Actions to current versions, fixes deprecation warnings, and bumps version to 1.6.1.

## Changes

### CI workflow
- `actions/checkout` v2 → v4
- `actions/setup-node` v1 → v4

### Release workflow
- `actions/checkout` v2 → v4
- `actions/setup-node` v1 → v4
- Replaced archived `actions/create-release@v1` and `actions/upload-release-asset@v1` with the `gh` CLI (`gh release create`)
- Fixed asset names: `github.ref` → `github.ref_name` (was producing `refs/tags/v1.6.0` in filenames)
- Added `contents: write` permission (required for release creation)

### Version
- Bumped version to 1.6.1